### PR TITLE
Execute proc in the context of the instance

### DIFF
--- a/lib/minitest/stub_any_instance.rb
+++ b/lib/minitest/stub_any_instance.rb
@@ -7,7 +7,7 @@ class Object
 
       define_method(name) do |*args|
         if val_or_callable.respond_to? :call then
-          val_or_callable.call(*args)
+          instance_exec(*args, &val_or_callable)
         else
           val_or_callable
         end

--- a/test/stub_any_instance_test.rb
+++ b/test/stub_any_instance_test.rb
@@ -33,4 +33,12 @@ class TestStubAnyInstance < MiniTest::Unit::TestCase
     assert_empty $stderr.string
     assert got_here
   end
+
+  def test_proc_has_access_to_self
+    twice_size = -> { self.size * 2 }
+    String.stub_any_instance(:length, twice_size) do
+      assert_equal 6, 'abc'.length
+    end
+  end
+
 end


### PR DESCRIPTION
Using instance_exec instead of Proc#call gives the proc access to self.*
and instance variables.