### PR TITLE
Ruby 2.3.0: Backup/restore the stubbed method only if I'm the owning class.

### DIFF
--- a/lib/minitest/stub_any_instance.rb
+++ b/lib/minitest/stub_any_instance.rb
@@ -2,8 +2,9 @@ class Object
   def self.stub_any_instance name, val_or_callable, &block
     new_name = "__minitest_any_instance_stub__#{name}"
 
+    owns_method = instance_method(name).owner == self
     class_eval do
-      alias_method new_name, name
+      alias_method new_name, name if owns_method
 
       define_method(name) do |*args|
         if val_or_callable.respond_to? :call then
@@ -17,9 +18,11 @@ class Object
     yield
   ensure
     class_eval do
-      undef_method name
-      alias_method name, new_name
-      undef_method new_name
+      remove_method name
+      if owns_method
+        alias_method name, new_name
+        remove_method new_name
+      end
     end
   end
 end

--- a/test/stub_any_instance_test.rb
+++ b/test/stub_any_instance_test.rb
@@ -2,6 +2,23 @@ require 'minitest/autorun'
 require 'stringio'
 require File.expand_path("../../lib/minitest/stub_any_instance", __FILE__)
 
+module StubAnyInstanceTest
+  class GrandparentClass
+    def foo(_a)
+      'bar'
+    end
+  end
+
+  class ParentClass < GrandparentClass
+    def foo
+      super(:a)
+    end
+  end
+
+  class ChildClass < ParentClass
+  end
+end
+
 class TestStubAnyInstance < MiniTest::Unit::TestCase
   def setup
     $stderr = StringIO.new
@@ -41,4 +58,13 @@ class TestStubAnyInstance < MiniTest::Unit::TestCase
     end
   end
 
+  def test_stub_method_not_implemented_in_grandchild_class
+    ::StubAnyInstanceTest::ChildClass.stub_any_instance(:foo, :result) do
+      assert_equal :result, ::StubAnyInstanceTest::ChildClass.new.foo
+    end
+  end
+
+  def test_stubbed_method_does_not_get_restored_to_non_owning_class
+    assert_equal 'bar', ::StubAnyInstanceTest::ChildClass.new.foo
+  end
 end


### PR DESCRIPTION
When removing methods, use remove_method to remove only my methods,
not inherited ones.

Fixes an issue with ruby 2.3.0-preview2 caused by
https://github.com/ruby/ruby/commit/c8854d2ca4be9ee6946e6d17b0e17d9ef130ee81
"Do not skip calling same methods in super"

Similar to https://github.com/rspec/rspec-mocks/pull/1043
which resolved https://github.com/rspec/rspec-mocks/issues/1042