### PR TITLE
Support added for BasicObject objects

### DIFF
--- a/lib/minitest/stub_any_instance.rb
+++ b/lib/minitest/stub_any_instance.rb
@@ -1,4 +1,4 @@
-class Object
+class BasicObject
   def self.stub_any_instance name, val_or_callable, &block
     new_name = "__minitest_any_instance_stub__#{name}"
 

--- a/test/stub_any_instance_test.rb
+++ b/test/stub_any_instance_test.rb
@@ -3,7 +3,7 @@ require 'stringio'
 require File.expand_path("../../lib/minitest/stub_any_instance", __FILE__)
 
 module StubAnyInstanceTest
-  class GrandparentClass
+  class GrandparentClass < BasicObject
     def foo(_a)
       'bar'
     end


### PR DESCRIPTION
Since some objects inherit from `BasicObject` without inheriting from `Object`, I needed to add the `stub_any_instance` method to `BasicObject`  instead of `Object`.

For example, if you need to stub Ruby on Rails mailing delivery, `ActionMailer::MessageDelivery` cannot use the `stub_any_instance` method because `Object` is not one of its ancestors, but `BasicObject` obviously is.

Object inherit from `BasicObject`, so all the objects with Object inheritance should still work. The tests were updated in order to inherit from `BasicObject`.